### PR TITLE
add dummy member to scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -90,6 +90,7 @@ enum TokenType {
 };
 
 typedef struct {
+  bool dummy; // C2016: C requires that a struct or union have at least one member
 } Scanner;
 
 static unsigned serialize(Scanner *scanner, char *buffer) { return 0; }


### PR DESCRIPTION
fix #4 

This would fix the build error, if you don't mind a dummy member.
Upstream has `tags`: https://github.com/tree-sitter/tree-sitter-html/blob/master/src/scanner.c#L24