### PR TITLE
CSS highlight improvement

### DIFF
--- a/corpus/go.txt
+++ b/corpus/go.txt
@@ -213,3 +213,26 @@ var advancedLinks = []Link{
                       (field_identifier)
                       (interpreted_string_literal))))))))))
 
+====
+Correctly display css components
+====
+
+package css
+
+css primaryClassName() {
+	color: red;
+}
+css className() {
+	color: red;
+}
+
+templ button(){
+	<button class={"button", className(), templ.KV(className(), primaryClassName()) }
+	>Click</button>
+}
+
+---
+
+
+
+

--- a/corpus/go.txt
+++ b/corpus/go.txt
@@ -212,27 +212,3 @@ var advancedLinks = []Link{
                     (keyed_element
                       (field_identifier)
                       (interpreted_string_literal))))))))))
-
-====
-Correctly display css components
-====
-
-package css
-
-css primaryClassName() {
-	color: red;
-}
-css className() {
-	color: red;
-}
-
-templ button(){
-	<button class={"button", className(), templ.KV(className(), primaryClassName()) }
-	>Click</button>
-}
-
----
-
-
-
-

--- a/queries/templ/highlights.scm
+++ b/queries/templ/highlights.scm
@@ -46,8 +46,11 @@
 (element_text) @string.special
 (style_element_text) @string.special
 
+(css_identifier) @keyword
 (css_property
   name: (css_property_name) @attribute)
+(css_property
+  name: (css_property_value) @string)
 
 (expression) @function.method
 (dynamic_class_attribute_value) @function.method

--- a/queries/templ/highlights.scm
+++ b/queries/templ/highlights.scm
@@ -46,11 +46,11 @@
 (element_text) @string.special
 (style_element_text) @string.special
 
-(css_identifier) @keyword
+(css_identifier) @function
 (css_property
   name: (css_property_name) @attribute)
 (css_property
-  name: (css_property_value) @string)
+  value: (css_property_value) @string)
 
 (expression) @function.method
 (dynamic_class_attribute_value) @function.method


### PR DESCRIPTION
@vrischmann so i was thinking i quickly add something to make the css stuff look nicer as mentioned in issue https://github.com/vrischmann/tree-sitter-templ/issues/9

i think i got it improved a little bit, although im not sure how to make it better for dynamic_class_attribute_value to reflect the parts of that statement, i would like that each call_expression looks like component_identifier to give it a coherent look.


