### PR TITLE
chore(just): make examples recipe self-contained

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,8 +13,10 @@ build: gen
 	npx node-gyp configure
 	npx node-gyp build
 
-examples:
-	tree-sitter parse -q -t "templ/**/*.templ"
+# Parse the templ examples, the same way the CI does.
+# Fetches the examples (templ submodule) and rebuilds the parser first.
+examples: gen init-templ
+	npx tree-sitter parse -q --stat "templ/**/*.templ"
 
 init-templ:
 	git submodule update --init --depth=1


### PR DESCRIPTION
## What

The `examples` recipe parses the templ examples locally, mirroring what the CI does. It was previously non-functional on its own: it relied on the `templ` submodule being checked out separately (via `just init-templ`) and used the system `tree-sitter` instead of the project's pinned `npx` version.

## Changes

- Wire `gen` and `init-templ` as dependencies of `examples`, so `just examples` regenerates the parser from the current `grammar.js` and fetches the examples before parsing — a single self-contained command.
- Use `npx tree-sitter` (matching the rest of the Justfile and CI's pinned version) instead of the system `tree-sitter`.
- Replace `-t` (per-file timing, noisy across 78 files) with `--stat` for a single summary line. `-q` is kept so only failing files print their parse tree.

Running `just examples` now reports:

```
Total parses: 78; successful parses: 78; failed parses: 0; success percentage: 100.00%
```