### PR TITLE
chore: automate templ submodule bumps

### DIFF
--- a/.github/workflows/bump-templ.yml
+++ b/.github/workflows/bump-templ.yml
@@ -1,0 +1,52 @@
+# Bumps the templ submodule to the latest upstream main and opens a PR when it
+# changes. CI then runs on that PR, so a parse regression in the updated
+# example files surfaces as a failed check.
+#
+# A PAT is used (the BUMP_TOKEN secret) instead of the default GITHUB_TOKEN,
+# because pushes performed with GITHUB_TOKEN do not trigger other workflows,
+# which would mean no CI on the PR.
+#
+# Setup: create a fine-grained PAT with "Contents: Read and write" and
+# "Pull requests: Read and write" for this repository, then add it as the
+# BUMP_TOKEN secret.
+name: Bump templ examples
+
+on:
+  schedule:
+    - cron: "17 3 * * 1" # every Monday at 03:17 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Bump templ submodule to latest main
+        run: |
+          git -C templ fetch --depth=1 origin main
+          git -C templ checkout FETCH_HEAD
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.BUMP_TOKEN }}
+          commit-message: "chore: bump templ examples submodule"
+          branch: chore/bump-templ-examples
+          delete-branch: true
+          title: "chore: bump templ examples"
+          body: |
+            Bumps the `templ` submodule to the latest upstream `main`, keeping
+            the local example set parsed by `just examples` in sync.
+
+            Created automatically by the `Bump templ examples` workflow.
+            Check the CI status below: a failed **Parse examples** step means
+            the grammar breaks on the updated example files.
+          labels: automated

--- a/Justfile
+++ b/Justfile
@@ -18,3 +18,17 @@ examples:
 
 init-templ:
 	git submodule update --init --depth=1
+
+# Advance the templ submodule to the latest upstream main, parse the examples
+# to check for regressions, and stage the bump. Review with
+# `git diff --cached -- templ` then commit and push.
+update-templ: gen
+	#!/usr/bin/env bash
+	set -euo pipefail
+	git submodule update --init --depth=1
+	git -C templ fetch --depth=1 origin main
+	git -C templ checkout FETCH_HEAD
+	echo "templ now at $(git -C templ rev-parse --short HEAD); parsing examples..."
+	npx tree-sitter parse -q --stat "templ/**/*.templ"
+	git add templ
+	echo "bump staged"


### PR DESCRIPTION
## Why

The `templ` submodule that feeds `just examples` is pinned, so it drifts behind upstream. Local parsing then stays green while CI — which clones the latest templ — goes red. That is exactly how the `test-attribute-comments` regression slipped through: the file did not exist in the pinned submodule (78 files), but CI clones latest `main` (86 files).

## What

**`just update-templ`** (new recipe): advances the submodule to the latest upstream `main`, parses the examples to surface regressions, and stages the bump when parsing is clean. Because `tree-sitter parse` exits non-zero on errors and the recipe runs under `set -e`, a broken bump fails loudly and is **not** auto-staged.

```
$ just update-templ
templ now at 04abee5; parsing examples...
templ/generator/test-attribute-comments/template.templ   (ERROR [44, 22] - [44, 23])
Total parses: 86; successful parses: 85; failed parses: 1
error: recipe `update-templ` failed with exit code 1
```

**`.github/workflows/bump-templ.yml`** (new): runs weekly (Monday 03:17 UTC, also `workflow_dispatch`), bumps the submodule to latest `main`, and opens a PR when it changed. CI then runs on that PR, so a parse regression in the new example files shows up as a failed **Parse examples** step.

## One-time setup required

The PR is opened with a **PAT** (the `BUMP_TOKEN` secret), not the default `GITHUB_TOKEN`. This is required because pushes made with `GITHUB_TOKEN` do not trigger other workflows, so CI would not run on the auto-PR.

To enable it, create a fine-grained PAT with **Contents: Read and write** and **Pull requests: Read and write** for this repository, then add it as the `BUMP_TOKEN` secret. Until then, the workflow will fail at the "Open pull request" step.

## Note

The `update-templ` recipe parses examples locally for immediate feedback, while CI's daily run and these bump PRs cover the upstream-facing signal. The underlying `//`-inside-a-string grammar bug (the thing currently turning CI red) is separate and not addressed here.