### PR TITLE
chore: bump templ examples

### DIFF
--- a/.github/workflows/bump-templ.yml
+++ b/.github/workflows/bump-templ.yml
@@ -35,7 +35,7 @@ jobs:
           git -C templ checkout FETCH_HEAD
 
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.BUMP_TOKEN }}
           commit-message: "chore: bump templ examples submodule"


### PR DESCRIPTION
Bumps the `templ` submodule to the latest upstream `main`, keeping
the local example set parsed by `just examples` in sync.

Created automatically by the `Bump templ examples` workflow.
Check the CI status below: a failed **Parse examples** step means
the grammar breaks on the updated example files.