### PR TITLE
fix: preserve keyword length during scanner backtracking

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -54,20 +54,20 @@ static bool lookahead_buffer_find_keyword(LookaheadBuffer *buffer,
                                           TSLexer *lexer, const char *str) {
   size_t length = strlen(str);
 
+  if (buffer->write_pos > length) {
+    return false;
+  }
+
   // First look in the buffer
-  for (size_t i = 0; i < buffer->write_pos && i < length; i++) {
+  for (size_t i = 0; i < buffer->write_pos; i++) {
     if (buffer->buf[i] != str[i]) {
       return false;
     }
-
-    length--;
   }
 
-  const char *str_remaining = &str[buffer->write_pos];
-
   // Otherwise fetch data from the lexer
-  for (size_t i = 0; i < length; i++) {
-    if (lexer->eof(lexer) || lexer->lookahead != str_remaining[i]) {
+  for (size_t i = buffer->write_pos; i < length; i++) {
+    if (lexer->eof(lexer) || lexer->lookahead != str[i]) {
       return false;
     }
 


### PR DESCRIPTION
Closes #152.\n\nlookahead_buffer_find_keyword now keeps the candidate length immutable, compares exactly the buffered prefix, rejects an overlong buffer, and indexes the remaining keyword from its original position. This prevents the NUL-terminator read and the false negative described in the issue.\n\nValidation:\n- 
px --yes tree-sitter-cli@0.26.11 test (76 parses passed)\n- git diff --check\n\nI also checked the focused C harness shape from the issue against the helper logic; a C compiler is not installed in this Windows environment, so that standalone harness could not be executed locally.