### PR TITLE
fix(grammar): allow digits in css property names

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -561,7 +561,7 @@ module.exports = grammar(GO, {
             )),
             ';'
         ),
-        css_property_name: $ => /[a-zA-Z\-]+/,
+        css_property_name: $ => /[a-zA-Z\-][a-zA-Z0-9\-]*/,
         css_property_value: $ => token(prec(1, /[^\s;{}][^;{}]*/)),
 
         // This matches a dynamic class attribute.

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8525,7 +8525,7 @@
     },
     "css_property_name": {
       "type": "PATTERN",
-      "value": "[a-zA-Z\\-]+"
+      "value": "[a-zA-Z\\-][a-zA-Z0-9\\-]*"
     },
     "css_property_value": {
       "type": "TOKEN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -8544,6 +8544,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 338:
       ACCEPT_TOKEN(sym_css_property_name);
       if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(338);
       END_STATE();

--- a/test/corpus/css.txt
+++ b/test/corpus/css.txt
@@ -385,3 +385,38 @@ templ Foobar() {
         (style_tag_end))
       (style_element
         (self_closing_style_tag)))))
+
+====
+CSS property name with digit
+====
+
+package main
+
+css grid() {
+  --col1width: 100px;
+}
+
+templ Foo() {
+  <div></div>
+}
+
+---
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (css_declaration
+    name: (css_identifier)
+    (parameter_list)
+    (css_property
+      name: (css_property_name)
+      value: (css_property_value)))
+  (component_declaration
+    name: (component_identifier)
+    (parameter_list)
+    (component_block
+      (element
+        (tag_start
+          name: (element_identifier))
+        (tag_end
+          name: (element_identifier))))))


### PR DESCRIPTION
Closes #131

## Summary

The `css_property_name` grammar pattern rejected digits, so CSS custom properties like `--col1width` were parsed as an `ERROR` node. The official templ parser (`templ/parser/v2/cssparser.go`) already allows digits in subsequent characters of a property name.

Change the pattern from `/[a-zA-Z\-]+/` to `/[a-zA-Z\-][a-zA-Z0-9\-]*/`: the first character is still a letter or hyphen, digits are allowed afterward.

## Commits

- `test: add corpus test for css property names with digits` — the test was verified to fail against the old parser
- `fix(grammar): allow digits in css property names` — grammar change + regenerated parser