### PR TITLE
fix(grammar): allow colon in element identifiers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -682,7 +682,7 @@ module.exports = grammar(GO, {
         _css_identifier: $ => alias($.identifier, $.css_identifier),
         _script_identifier: $ => alias($.identifier, $.script_identifier),
 
-        element_identifier: $ => /[a-zA-Z0-9\-]+/,
+        element_identifier: $ => /[a-zA-Z0-9\-:]+/,
 
         // Taken from https://github.com/tree-sitter/tree-sitter-html/blob/master/grammar.js
         attribute_name: _ => /[^<>"'/=\s]+/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8921,7 +8921,7 @@
     },
     "element_identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9\\-]+"
+      "value": "[a-zA-Z0-9\\-:]+"
     },
     "attribute_name": {
       "type": "PATTERN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -7039,7 +7039,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(53);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -7062,7 +7062,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(56);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -8523,7 +8523,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 333:
       ACCEPT_TOKEN(anon_sym_style);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -9967,7 +9967,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 467:
       ACCEPT_TOKEN(anon_sym_script);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10049,7 +10049,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'c') ADVANCE(484);
       if (lookahead == 't') ADVANCE(486);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10057,7 +10057,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 'e') ADVANCE(333);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10065,7 +10065,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 'i') ADVANCE(483);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10073,7 +10073,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 'l') ADVANCE(480);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10081,7 +10081,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 'p') ADVANCE(485);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10089,7 +10089,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 'r') ADVANCE(481);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10097,7 +10097,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 't') ADVANCE(467);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
@@ -10105,14 +10105,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == 'y') ADVANCE(482);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();
     case 487:
       ACCEPT_TOKEN(sym_element_identifier);
       if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+          ('0' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(487);
       END_STATE();

--- a/test/corpus/attributes.txt
+++ b/test/corpus/attributes.txt
@@ -872,3 +872,36 @@ templ test() {
             (attribute_name)
             (quoted_attribute_value
               (attribute_value))))))))
+
+====
+Element name with colon
+====
+
+package main
+
+templ Foo() {
+	<svg:rect width="10"/>
+	<maps:map></maps:map>
+}
+
+---
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (component_declaration
+    name: (component_identifier)
+    (parameter_list)
+    (component_block
+      (element
+        (self_closing_tag
+          name: (element_identifier)
+          (attribute
+            name: (attribute_name)
+            value: (quoted_attribute_value
+              (attribute_value)))))
+      (element
+        (tag_start
+          name: (element_identifier))
+        (tag_end
+          name: (element_identifier))))))


### PR DESCRIPTION
## Problem

`element_identifier` was defined as `/[a-zA-Z0-9\-]+/` with no colon, so namespaced or qualified element names such as `<svg:rect>` and `<maps:map>` broke: the name stopped at the first segment (`svg`, `maps`) and the colon-prefixed tail (`:rect`, `:map`) became an `ERROR`.

This diverges from the official templ parser, whose `elementNameSubsequent` includes `:`.

## Fix

Add `:` to the regex:

```js
element_identifier: $ => /[a-zA-Z0-9\-:]+/,
```

## Approach

Done as two commits, test-first:

1. **`test(corpus): add case for element name with colon`** — adds a corpus test to `test/corpus/attributes.txt` covering `<svg:rect width="10"/>` and `<maps:map></maps:map>`. Verified it fails against the unmodified grammar (`:rect` misread as an attribute, `:map` tail as an `ERROR`).
2. **`fix(grammar): allow colon in element identifiers`** — adds `:` to `element_identifier` and regenerates the parser. The full corpus suite goes green (79/79).

The grammar stays more permissive than the official parser on the first character (it allows uppercase/digits to start a name); that's acceptable for a tree-sitter grammar, so only the missing `:` is added.

Closes #132